### PR TITLE
fix: optional schedule_name

### DIFF
--- a/backend/src/job/job.service.ts
+++ b/backend/src/job/job.service.ts
@@ -554,9 +554,9 @@ export class JobService {
 
         case JobStatus.DEPLOYED: {
           // Job already read from SFTP for publisher role
-          const fileData = existingJob as Job;
+          const fileData = existingJob as Job & { schedule_name?: string };
 
-          const deployPayload: Job = structuredClone(fileData);
+          const deployPayload: Job & { schedule_name?: string } = structuredClone(fileData);
           deployPayload.publishing_status = ScheduleStatus.ACTIVE;
 
           if (type === ConfigType.PULL) {


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
build error for optional schedule_name

## How was it tested?
- [x] Locally
- [x] Development Environment
- [x] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job deployments now support optional schedule information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->