### PR TITLE
feat: update the copyright provided by the tazama team

### DIFF
--- a/frontend/src/features/auth/pages/Login.tsx
+++ b/frontend/src/features/auth/pages/Login.tsx
@@ -3,6 +3,7 @@
 import Logo from '@assets/logo.png';
 import tazamaLogo from '@assets/tazamaLogo.svg';
 import treeImage from '@assets/treeImage.png';
+import { APACHE_LICENSE_URL } from '../../../utils/constants';
 import { yupResolver } from '@hookform/resolvers/yup';
 import {
   AppBar,
@@ -332,9 +333,20 @@ export const Login: React.FC = () => {
             <Typography
               variant="body2"
               color="text.secondary"
+              align="center"
               sx={{ mt: '130px' }}
             >
-              &copy; {new Date().getFullYear()} Tazama. Powered by Paysys Labs.
+              &copy; {new Date().getFullYear()} LF Charities, Inc. and contributors to the Tazama project
+              <br />
+              Licensed under{' '}
+              <a
+                href={APACHE_LICENSE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'inherit' }}
+              >
+                Apache-2.0
+              </a>
             </Typography>
           </Box>
         </Box>

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,1 +1,1 @@
-export const APACHE_LICENSE_URL = 'https://github.com/tazama-lf/connection-studio/blob/dev/LICENSE';
+export const APACHE_LICENSE_URL = 'https://github.com/tazama-lf/connection-studio/blob/main/LICENSE';

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const APACHE_LICENSE_URL = 'https://github.com/tazama-lf/connection-studio/blob/dev/LICENSE';


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
This pull request updates the login page footer to provide more accurate project attribution and licensing information. It also introduces a new constant for the Apache license URL to improve maintainability.

**Login page attribution and licensing update:**

* The footer on the `Login` page now credits "LF Charities, Inc. and contributors to the Tazama project" instead of "Tazama. Powered by Paysys Labs," and adds a clearly labeled link to the Apache-2.0 license. The text is also centered for better presentation.

**Code maintainability:**

* Introduced a new constant `APACHE_LICENSE_URL` in `constants.ts` to store the license URL, which is now used in the login page footer. [[1]](diffhunk://#diff-a18c6dbf8c054e11702645a38a56f6da50b48dc42efb8e433927b012d76b0784R1) [[2]](diffhunk://#diff-894a3b4adfe57259722414b39a27adcf7db50e7536895d8cad14c86e0f013511R6)

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated login page footer to replace previous branding with copyright attribution for LF Charities, Inc. and project contributors.
  * Added a visible Apache-2.0 license link in the footer.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/connection-studio/pull/46)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->