### PR TITLE
fix: /simulation/run was breaking due to root level TenantId field

### DIFF
--- a/backend/src/simulation/simulation.service.ts
+++ b/backend/src/simulation/simulation.service.ts
@@ -156,6 +156,7 @@ export class SimulationService {
       const hasMappings = config.mapping && config.mapping.length > 0;
 
       if (hasMappings) {
+        parsedPayload.TenantId = tenantId;
         const mappingValidationStage = this.stageValidateMappings(
           parsedPayload,
           config.mapping ?? [],


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

/simulation/run API was breaking when we mapped the TenantId field to some field in the payload.

That was because TenantId does not exist on payload, rather as a reserved field that comes from the JWT token.

So extracted the token from JWT and appended it to the parsedPayload.

## Why are we doing this?

So that simulation can work as per expected behaviour.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant context handling in simulation processing to ensure correct tenant data isolation during mapping operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->