### PR TITLE
fix: update notifyDems method to include token parameter

### DIFF
--- a/backend/src/config/config.service.ts
+++ b/backend/src/config/config.service.ts
@@ -664,7 +664,7 @@ export class ConfigService {
     }
 
     try {
-      await this.demsClient.notifyDems(id.toString(), tenantId, publishingStatus);
+      await this.demsClient.notifyDems(id.toString(), tenantId, publishingStatus, token);
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
       this.logger.error(

--- a/backend/src/services/dems-client.service.ts
+++ b/backend/src/services/dems-client.service.ts
@@ -27,6 +27,7 @@ export class DemsClient {
     configId: string,
     _tenantId: string,
     publishingStatus: 'active' | 'inactive',
+    token: string,
   ): Promise<void> {
     const demsUrl = this.configService.get<string>('DEMS_URL')!;
 
@@ -40,7 +41,7 @@ export class DemsClient {
       'PATCH',
       demsUrl,
       `/config-notify/${configId}`,
-      '',
+      token,
       { publishing_status: publishingStatus },
     );
 

--- a/backend/test/services/dems-client.service.spec.ts
+++ b/backend/test/services/dems-client.service.spec.ts
@@ -57,6 +57,7 @@ describe('DemsClient', () => {
     const mockConfigId = 'config-123';
     const mockTenantId = 'tenant-456';
     const demsUrl = 'http://dems:3002';
+    const token = 'mock-token';
 
     beforeEach(() => {
       configService.get.mockImplementation((key: string) => {
@@ -67,7 +68,7 @@ describe('DemsClient', () => {
     });
 
     it('should PATCH to the correct URL with active status', async () => {
-      await service.notifyDems(mockConfigId, mockTenantId, 'active');
+      await service.notifyDems(mockConfigId, mockTenantId, 'active', token);
 
       expect(httpService.patch).toHaveBeenCalledWith(
         `${demsUrl}/config-notify/${mockConfigId}`,
@@ -77,7 +78,7 @@ describe('DemsClient', () => {
     });
 
     it('should PATCH to the correct URL with inactive status', async () => {
-      await service.notifyDems(mockConfigId, mockTenantId, 'inactive');
+      await service.notifyDems(mockConfigId, mockTenantId, 'inactive', token);
 
       expect(httpService.patch).toHaveBeenCalledWith(
         `${demsUrl}/config-notify/${mockConfigId}`,
@@ -87,7 +88,7 @@ describe('DemsClient', () => {
     });
 
     it('should log success after patching', async () => {
-      await service.notifyDems(mockConfigId, mockTenantId, 'active');
+      await service.notifyDems(mockConfigId, mockTenantId, 'active', token);
 
       expect(loggerService.log).toHaveBeenCalledWith(
         expect.stringContaining(mockConfigId),
@@ -101,7 +102,7 @@ describe('DemsClient', () => {
       );
 
       await expect(
-        service.notifyDems(mockConfigId, mockTenantId, 'active'),
+        service.notifyDems(mockConfigId, mockTenantId, 'active', token),
       ).rejects.toThrow('Internal server error');
     });
 
@@ -109,7 +110,7 @@ describe('DemsClient', () => {
       httpService.patch.mockReturnValue(throwError(() => 'plain string error'));
 
       await expect(
-        service.notifyDems(mockConfigId, mockTenantId, 'active'),
+        service.notifyDems(mockConfigId, mockTenantId, 'active', token),
       ).rejects.toThrow('Internal server error');
     });
 
@@ -126,13 +127,14 @@ describe('DemsClient', () => {
 
   describe('Error Handling', () => {
     it('should not throw errors in notifyDems even if HTTP fails', async () => {
+      const token = 'mock-token';
       configService.get.mockReturnValue('http://dems:3002');
       httpService.patch.mockReturnValue(
         throwError(() => new Error('HTTP failed')),
       );
 
       await expect(
-        service.notifyDems('config-id', 'tenant-id', 'active'),
+        service.notifyDems('config-id', 'tenant-id', 'active', token),
       ).rejects.toThrow('Internal server error');
     });
   });


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
1. The logic that was responsible for updating the publishing_status in cache missed the token when sending request from TCS-backend to DEMS. As a result the DB update was working but cache was stale. We passed the token and now that issue is fixed.


## Why are we doing this?

So that publishing_status can be successfully updated in cache and we overcome the stale data problem.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Publishing status update notifications now include required authentication credentials for improved reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->